### PR TITLE
修复段落内多个 code 标签没有正确高亮的问题

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -60,6 +60,7 @@
                     'target': '.commentmetadata a:first-child,.infos time,.post-list time'
                 });
                 <?php } if(!get_theme_mod('biji_setting_prettify')){ ?>
+                document.querySelectorAll('p code').forEach(it => it.classList.add('prettyprint'));
                 prettyPrint();
                 <?php }?>
 
@@ -88,7 +89,10 @@
             // support MathJax
             if (typeof MathJax !== 'undefined') MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
             // support google code prettify
-            if (typeof prettyPrint !== 'undefined') prettyPrint();
+            if (typeof prettyPrint !== 'undefined') {
+                document.querySelectorAll('p code').forEach(it => it.classList.add('prettyprint'));
+                prettyPrint();
+            }
             // support 百度统计
             if (typeof _hmt !== 'undefined') _hmt.push(['_trackPageview', location.pathname + location.search]);
             // support google analytics

--- a/footer.php
+++ b/footer.php
@@ -60,7 +60,6 @@
                     'target': '.commentmetadata a:first-child,.infos time,.post-list time'
                 });
                 <?php } if(!get_theme_mod('biji_setting_prettify')){ ?>
-                document.querySelectorAll('p code').forEach(it => it.classList.add('prettyprint'));
                 prettyPrint();
                 <?php }?>
 
@@ -96,10 +95,7 @@
             // support MathJax
             if (typeof MathJax !== 'undefined') MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
             // support google code prettify
-            if (typeof prettyPrint !== 'undefined') {
-                document.querySelectorAll('p code').forEach(it => it.classList.add('prettyprint'));
-                prettyPrint();
-            }
+            if (typeof prettyPrint !== 'undefined') prettyPrint();
             // support 百度统计
             if (typeof _hmt !== 'undefined') _hmt.push(['_trackPageview', location.pathname + location.search]);
             // support google analytics

--- a/functions.php
+++ b/functions.php
@@ -174,7 +174,7 @@ if(!get_theme_mod('biji_setting_prettify')) {
     function dangopress_esc_html($content)
     {
         if (!is_feed() || !is_robots()) {
-            $content = preg_replace('/<code(.*)>/i', "<code class=\"prettyprint\" \$1>", $content);
+            $content = preg_replace('/<code(.*?)>/i', "<code class=\"prettyprint\" \$1>", $content);
         }
         $regex = '/(<code.*?>)(.*?)(<\/code>)/sim';
         return preg_replace_callback($regex, 'dangopress_esc_callback', $content);


### PR DESCRIPTION
当一个段落内含有多个内联代码时，只有第一个代码标签有正确的代码高亮。
这可能提示 wp 本身的问题或者主题上的一些遗漏；这个写法姑且算作一个 workaround.
