### PR TITLE
使自动生成摘要忽略 More 块之后的内容

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,7 +19,9 @@
                                 <?php if (post_password_required()) {
                                     the_content();
                                 } else {
-                                    echo mb_strimwidth(strip_shortcodes(strip_tags(apply_filters('the_content', $post->post_excerpt ?: $post->post_content))), 0, 220, '...');
+                                    $content = get_post_field('post_content', get_the_ID());
+									$content_parts = get_extended($content);
+                                    echo mb_strimwidth(strip_shortcodes(strip_tags(apply_filters('the_content', $post->post_excerpt ?: $content_parts['main']))), 0, 220, '...');
                                 } ?>
                             </p>
                         </main>


### PR DESCRIPTION
当前的自动摘要会一并获取 More 块之后的内容（同时由于剥离标签，有些时候会使得 More 前和 More 后的文字粘在一起）。本次更改只获取文章 More 块之前的内容并生成自动摘要。