### PR TITLE
更新：将文章结尾显示信息移动至<article>后

### DIFF
--- a/inc/content.php
+++ b/inc/content.php
@@ -6,6 +6,8 @@
             the_content();
         }; ?>
     </article>
+    <?= get_theme_mod('biji_setting_postAd'); ?>
+
     <ul class="tags">
         <?php the_tags('<li>', '</li><li>', '</li>') ?>
     </ul>
@@ -13,5 +15,4 @@
         <div class="alignleft"><?php previous_post_link('%link'); ?></div>
         <div class="alignright"><?php next_post_link('%link'); ?></div>
     </nav>
-    <?= get_theme_mod('biji_setting_postAd'); ?>
 </section>


### PR DESCRIPTION
原代码中文章结尾显示信息主题变量biji_setting_postAd在文章标签和文章切换链接后面，显示效果不佳，且非真正意义上的“文章结尾显示信息”。

该变更将biji_setting_postAd的显示移动至<article>之后，显示内容在文章内容最后，且在文章标签之前，对于类似CC协议的声明可以很好地呈现文章声明的效果。